### PR TITLE
Further zsh completion

### DIFF
--- a/_pyb
+++ b/_pyb
@@ -1,37 +1,43 @@
 #compdef pyb
 
-
-command -v pyb >/dev/null 2>&1 || return 0
-pyb -Qt >/dev/null 2>&1 || return 0
-
-local -a common_opts
-common_opts=(
+local -a simple_opts extended_opts
+simple_opts=(
+        '--start-project[Initialize a new project structure]'
         '-v[Verbose output]'
         '-X[Debug output]'
+        '-h[Show help]'
+)
+extended_opts=(
         '-q[Quiet mode]'
         '-Q[Very quiet mode]'
         '-C[Disable colored output]'
-        '-h[Show help]'
-        '--start-project[Initialize a new project structure]'
         '--update-project[Update build descriptors and python project structure]'
         '-t[Show available tasks]'
         '-T[List execution plan tasks]'
 )
 
-_arguments -C '*:Task:->tasks' $common_opts
+if ! command -v pyb > /dev/null 2>&1; then
+    _message "unable to complete, no pyb found :("
 
-case "$state" in
-    (tasks)
+elif ! pyb -Qt > /dev/null 2>&1; then
+    _message "unable to find a build.py, limited completion available"
+    _arguments -s $simple_opts
 
-    local tasks; tasks=()
+else
+    _arguments -C '*:Task:->tasks' $simple_opts $extended_opts
 
-    pyb -Qt | while read TASK_LINE; do
-        tasks+=( $TASK_LINE )
-    done
+    case "$state" in
+        (tasks)
 
-    _arguments -s $common_opts
+        local tasks; tasks=()
 
+        pyb -Qt | while read TASK_LINE; do
+            tasks+=( $TASK_LINE )
+        done
 
-    _describe -t tasks 'tasks' tasks
-    ;;
-esac
+        _arguments -s $simple_opts $extended_opts
+
+        _describe -t tasks 'tasks' tasks
+        ;;
+    esac
+fi

--- a/_pyb
+++ b/_pyb
@@ -16,6 +16,14 @@ extended_opts=(
         '-T[List execution plan tasks]'
 )
 
+__pyb_tasks(){
+    local tasks;
+    pyb -Qt | while read TASK_LINE; do
+        tasks+=( $TASK_LINE )
+    done
+    _describe -t tasks 'tasks' tasks
+}
+
 # no pyb available at all
 if ! command -v pyb > /dev/null 2>&1; then
     _message "unable to complete, no pyb found :("
@@ -31,16 +39,8 @@ else
 
     case "$state" in
         (tasks)
-
-        local tasks; tasks=()
-
-        pyb -Qt | while read TASK_LINE; do
-            tasks+=( $TASK_LINE )
-        done
-
-        _arguments -s $simple_opts $extended_opts
-
-        _describe -t tasks 'tasks' tasks
+            _arguments -s $simple_opts $extended_opts
+            __pyb_tasks
         ;;
     esac
 fi

--- a/_pyb
+++ b/_pyb
@@ -18,7 +18,7 @@ common_opts=(
         '-T[List execution plan tasks]'
 )
 
-_arguments -C '*:Task:->tasks' $common_opts && ret=0
+_arguments -C '*:Task:->tasks' $common_opts
 
 case "$state" in
     (tasks)
@@ -32,8 +32,6 @@ case "$state" in
     _arguments -s $common_opts
 
 
-    _describe -t tasks 'tasks' tasks && ret=0
+    _describe -t tasks 'tasks' tasks
     ;;
 esac
-
-return 1

--- a/_pyb
+++ b/_pyb
@@ -16,13 +16,16 @@ extended_opts=(
         '-T[List execution plan tasks]'
 )
 
+# no pyb available at all
 if ! command -v pyb > /dev/null 2>&1; then
     _message "unable to complete, no pyb found :("
 
+# no build.py in current directory, presumably
 elif ! pyb -Qt > /dev/null 2>&1; then
     _message "unable to find a build.py, limited completion available"
     _arguments -s $simple_opts
 
+# the full monty
 else
     _arguments -C '*:Task:->tasks' $simple_opts $extended_opts
 


### PR DESCRIPTION
@mriehl here, give this a try. Main feature is code-cleanup and can now also has limited completion when there is no `build.py` available, so for example `--start-project` should work.

Also, I see there are still many things missing from the completion, Worse though the help section of pybuilder itself seems a bit historically grown and cobbled together. Would it be worth doing a cleanup round there?

Lastly, we can enhance the zsh completion greately by providing context sensitive completion for certain options. Imagine doing:

```
pyb -E <tab>
```

And being offered the available environments for completion. Of course this requires pybuilder to report those beforehand, but that shouldn't be a problem.

Anyway, one step at a time.
